### PR TITLE
Feature/api upgrade

### DIFF
--- a/impact/__init__.py
+++ b/impact/__init__.py
@@ -8,7 +8,7 @@ from qgis.core import *
 from urllib import request
 
 standalone_mode = False
-staging_mode = False
+staging_mode = True
 
 
 def setStandalone():
@@ -74,9 +74,10 @@ def fetch_non_blocking(url, callback, onerror, postData=None, headers=None):
         if postData is not None:
             if "Content-Type" not in headers:
                 headers["Content-Type"] = "application/json"
-            QgsMessageLog.logMessage(
-                "POST-request to " + url + " with headers " + json.dumps(headers),
-                'ImPact Toolbox', level=Qgis.Info)
+            msg = "POST-request to " + url + " with headers " + json.dumps(headers)
+            if staging_mode:
+                msg += " and post-data "+json.dumps(postData)
+            QgsMessageLog.logMessage(msg, 'ImPact Toolbox', level=Qgis.Info)
 
             req = request.Request(url, data=json.dumps(postData).encode('UTF-8'),
                                   headers=headers)  # this will make the method "POST"
@@ -220,23 +221,25 @@ def generate_layer_report(features):
                 has_count_rev += 1
         except:
             pass
-        
-    if (has_count + has_count_rev ) == 0:
+
+    if (has_count + has_count_rev) == 0:
         return "No lines have a field 'count' or 'count_rev' set. Nothing will be routeplanned. Select a different layer or add the appropriate values"
 
-    total_str ="This layer contains " + str(        len(features)) + " lines. "
-    forward_count_str = str( has_count) + " of these lines have the field 'count' set for a total sum of " + str(
+    total_str = "This layer contains " + str(len(features)) + " lines. "
+    forward_count_str = str(has_count) + " of these lines have the field 'count' set for a total sum of " + str(
         total_count)
     backward_count_str = "No lines have 'count_rev' set."
-    if(has_count_rev > 0):
-        backward_count_str =  str(has_count_rev) + " of the lines have the field 'count_rev' set for a total of " + str( total_count_rev)   
+    if (has_count_rev > 0):
+        backward_count_str = str(has_count_rev) + " of the lines have the field 'count_rev' set for a total of " + str(
+            total_count_rev)
     count_rev_expl_str = "Use 'count_rev' to generate planned routes in the reverse direction of the line"
-    
+
     has_null_str = ""
     if count_is_null > 0:
-        has_null_str = "\n"+ str(count_is_null)+" of the lines have NULL as count. They will be routeplanned, but their count will be interpreted as 0"
-    
-    return "\n".join([total_str , forward_count_str + has_null_str, "", backward_count_str,count_rev_expl_str])
+        has_null_str = "\n" + str(
+            count_is_null) + " of the lines have NULL as count. They will be routeplanned, but their count will be interpreted as 0"
+
+    return "\n".join([total_str, forward_count_str + has_null_str, "", backward_count_str, count_rev_expl_str])
 
 
 def transform_layer_to_WGS84(layer):

--- a/impact/impact_api.py
+++ b/impact/impact_api.py
@@ -163,22 +163,18 @@ class impact_api(object):
         url = API_PATH + path + "/profiles"
         
         def withData(data):
-            self.log("Got supported profiles from "+url+":"+data)
             profiles = []
             parsed = json.loads(data)["profiles"]
             for element in parsed:
                 type = element["type"]
                 profile = element["name"]
 
-                self.log(type)
-                self.log(profile)
-
                 if profile == "":
                     profiles.append(type)
                 else:
                     profiles.append(type+"."+profile)
             self.supported_profiles[path] = profiles
-            self.log("Got supported profiles from "+url+": "+", ".join(profiles))
+            self.log("Got "+str(len(profiles))+" supported profiles from "+url)
             callback(profiles)
             
         def onError(e):

--- a/impact/impact_api.py
+++ b/impact/impact_api.py
@@ -5,13 +5,14 @@ from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtNetwork import QNetworkRequest
 from qgis.core import Qgis, QgsMessageLog, QgsBlockingNetworkRequest
 
-from . import fetch_non_blocking, staging_mode
+from . import fetch_non_blocking, fetch_blocking, staging_mode
 
 BASE_URL_IMPACT_STAGING = "https://staging.anyways.eu/impact/"
 BASE_URL_IMPACT =  "https://api.anyways.eu/" if not staging_mode else BASE_URL_IMPACT_STAGING
 BASE_URL_IMPACT_META = "https://www.anyways.eu/impact/"  if not staging_mode else "https://staging.anyways.eu/impact/"
-API_PATH = "https://api.anyways.eu/publish/"
-IMPACT_API_PATH = "https://api.anyways.eu/impact/"
+API_PATH = "https://api.anyways.eu/publish/" if not staging_mode else "https://staging.anyways.eu/api/publish/prototype/"
+IMPACT_API_PATH = "https://api.anyways.eu/impact/" if not staging_mode else "https://staging.anyways.eu/api/impact/"
+EDIT_API_PATH = "https://api.anyways.eu/edit/" if not staging_mode else "https://staging.anyways.eu/api/edit/"
 
 SUPPORTED_PROFILES = ["car", "car.shortest", "car.opa", "car.default", "car.classifications",
                       "car.classifications_aggressive", "pedestrian", "pedestrian.shortest", "pedestrian.default",
@@ -84,7 +85,10 @@ class impact_api(object):
             return reply.errorString().endswith("Internal Server Error")
 
     def routing_url_for_instance(self, branch):
-        return API_PATH + branch
+        # https://github.com/anyways-open/impact-qgis-plugin/issues/29
+        metaurl = EDIT_API_PATH + "branch/" + branch
+        commit_id = json.loads(fetch_blocking(metaurl))["commit"]["id"]
+        return API_PATH + "commit/" + commit_id
 
     def routing_url_for_instance_legacy(self, token, instance = ""):
         return API_PATH + token + "/" + instance
@@ -156,10 +160,10 @@ class impact_api(object):
 
         if path in self.supported_profiles:
             callback(self.supported_profiles[path])
-        url = BASE_URL_IMPACT + "/publish/"+path+"/profiles"
+        url = API_PATH + path + "/profiles"
         
         def withData(data):
-            self.log("Got supported profiles from "+url)
+            self.log("Got supported profiles from "+url+":"+data)
             profiles = []
             parsed = json.loads(data)["profiles"]
             for element in parsed:
@@ -273,7 +277,6 @@ class impact_api(object):
             # try:
             QgsMessageLog.logMessage("repsonse ok", 'ImPact Toolbox', level=Qgis.Info)
             project = json.loads(response)
-            QgsMessageLog.logMessage("data for this project (impact instance):" + str(project), 'ImPact Toolbox', level=Qgis.Info)
             scenarios = project["scenarios"]
             callback(scenarios)
             # except Exception:

--- a/impact/routing_api.py
+++ b/impact/routing_api.py
@@ -23,10 +23,10 @@ class routing_api(object):
                  auth_token=None):
         
         if(baseurl == None):
+            baseurl="https://routing.anyways.eu/api"
             if staging_mode:
-                baseurl = "https://staging.anyways.eu/api/routing"
-            else:
-                baseurl="https://routing.anyways.eu/api"
+                # baseurl = "https://staging.anyways.eu/api/routing"
+                pass
         
         
         self._api_key = api_key
@@ -101,6 +101,12 @@ class routing_api(object):
             headers = {
                 "Authorization": self.auth_token
             }
+            
+        if not self.is_impact_backend:
+            # the old api.anyways.eu/routing takes 'lat,lon'
+            fromCoors = list(map(lambda c : list(reversed(c)), fromCoors))
+            toCoors = list(map(lambda c : list(reversed(c)), toCoors))
+            
         postData = {
             "profile": profile,
             "from": fromCoors,

--- a/impact/routing_api.py
+++ b/impact/routing_api.py
@@ -24,7 +24,7 @@ class routing_api(object):
         
         if(baseurl == None):
             if staging_mode:
-                baseurl = "https://staging.anyways.eu/routing-api"
+                baseurl = "https://staging.anyways.eu/api/routing"
             else:
                 baseurl="https://routing.anyways.eu/api"
         
@@ -101,8 +101,9 @@ class routing_api(object):
             headers = {
                 "Authorization": self.auth_token
             }
-        fetch_non_blocking(url, callback, onError, postData={
+        postData = {
             "profile": profile,
             "from": fromCoors,
             "to": toCoors
-        }, headers=headers)
+        }
+        fetch_non_blocking(url, callback, onError, postData=postData, headers=headers)

--- a/metadata.prod.txt
+++ b/metadata.prod.txt
@@ -6,7 +6,7 @@
 name=Impact toolbox
 qgisMinimumVersion=3.0
 description=This plugin automates access to the ANYWAYS API
-version=0.8.2
+version=0.9.0
 author=ANYWAYS BV
 email=support@anyways.eu
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -6,7 +6,7 @@
 name=Impact toolbox
 qgisMinimumVersion=3.0
 description=This plugin automates access to the ANYWAYS API
-version=0.8.2
+version=0.9.0
 author=ANYWAYS BV
 email=support@anyways.eu
 


### PR DESCRIPTION
First version which works with the new (prototype) publish API.

Before this can be merged, a few finishing touches should be made:

- This version is in _staging mode_, which means it'll use the staging endpoints. Before pushing a production version, this should be disabled [here](https://github.com/anyways-open/impact-qgis-plugin/blob/4a4e2f8bd66df0453000c0bf8dd3a6a02ce5e0f4/impact/__init__.py#L11)
- The staging-routing-api seems to be malfunctioning. For now, staging mode still uses the production version for testing. Should be fixed [here](https://github.com/anyways-open/impact-qgis-plugin/blob/4a4e2f8bd66df0453000c0bf8dd3a6a02ce5e0f4/impact/routing_api.py#L28)
- The publish-api path currently has a `prototype`-part in the URL. This part should be dropped [here](https://github.com/anyways-open/impact-qgis-plugin/blob/4a4e2f8bd66df0453000c0bf8dd3a6a02ce5e0f4/impact/impact_api.py#L13) once the prototype is merged into develop/production